### PR TITLE
Fix missing chmod from deploy_dockerhub.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ script:
   - npm run test
 deploy:
   provider: script
-  script: deploy_dockerhub.sh
+  script: "./deploy_dockerhub.sh"
   on:
     branch: master

--- a/deploy_dockerhub.sh
+++ b/deploy_dockerhub.sh
@@ -5,6 +5,15 @@
 #
 # DON'T RUN MANUALLY UNLESS YOU KNOW WHAT YOU'RE DOING! -Joona
 
+DOCKER_TAG_NAME=ohtuprojektiilmo/ohtuback
+
+echo 'Logging in with Docker'
 docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-docker build -t ohtuprojektiilmo/ohtuback .
-docker push ohtuprojektiilmo/ohtuback
+
+echo "Building $DOCKER_TAG_NAME"
+docker build -t $DOCKER_TAG_NAME .
+
+echo 'Pushing to dockerhub'
+docker push $DOCKER_TAG_NAME
+
+echo 'Deployed!'


### PR DESCRIPTION
Deploy script was failing on Travis because deploy_dockerhub.sh was missing
chmod +x (execute permission).

Also added a few `echo`s to the script.