### PR TITLE
Fix API contract change caused by aa8f1c5a

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -24,7 +24,7 @@ usersRouter.put('/:studentNumber', checkLogin, async (req, res) => {
 
     const updatedUser = await user.update({ email })
     const refreshedUser = await updatedUser.reload()
-    res.status(200).json({ refreshedUser })
+    res.status(200).json({ user: refreshedUser })
   } catch (error) {
     console.log(error)
     res.status(500).json({ error: 'database error' })


### PR DESCRIPTION
PUT /api/users/:student_number used to return an object of shape
```
{ "user": ... }
```
but the commit changed it into
```
{ "refreshedUser": ... }
```
which breaks the frontend's post-registration handling in updateUser().

Fixed by renaming the object.