### PR TITLE
Remove 9s timeout before db conn, crash if fail

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -6,82 +6,81 @@ const db = {}
 db.connect = () => {
   const sequelizeConfig = config[process.env.NODE_ENV]
 
-  setTimeout(function() {
-    const sequelize = new Sequelize(sequelizeConfig)
+  const sequelize = new Sequelize(sequelizeConfig)
 
-    sequelize
-      .authenticate()
-      .then(() => {
-        console.log('Connection has been established successfully.')
-      })
-      .catch((err) => {
-        console.error('Unable to connect to the database:', err)
-      })
-
-    const UserModel = require('./user')
-    const GroupModel = require('./group')
-    const TopicModel = require('./topic')
-    const TopicDateModel = require('./topic_date')
-    const RegistrationModel = require('./registration')
-    const ConfigurationModel = require('./configuration')
-    const RegistrationQuestionSetModel = require('./registration_question_set')
-    const ReviewQuestionSetModel = require('./review_question_set')
-    //const Review = require('./review')
-    //const Review_answer = require('./review_answer')
-    const RegistrationManagementModel = require('./registration_management')
-
-    const User = UserModel(sequelize, Sequelize)
-    const Group = GroupModel(sequelize, Sequelize)
-    const Topic = TopicModel(sequelize, Sequelize)
-    const TopicDate = TopicDateModel(sequelize, Sequelize)
-    const Registration = RegistrationModel(sequelize, Sequelize)
-    const Configuration = ConfigurationModel(sequelize, Sequelize)
-    const RegistrationQuestionSet = RegistrationQuestionSetModel(
-      sequelize,
-      Sequelize
-    )
-    const ReviewQuestionSet = ReviewQuestionSetModel(sequelize, Sequelize)
-    const RegistrationManagement = RegistrationManagementModel(
-      sequelize,
-      Sequelize
-    )
-
-    db.User = User
-    db.Group = Group
-    db.Topic = Topic
-    db.TopicDate = TopicDate
-    db.Registration = Registration
-    db.Configuration = Configuration
-    db.RegistrationQuestionSet = RegistrationQuestionSet
-    db.ReviewQuestionSet = ReviewQuestionSet
-    db.RegistrationManagement = RegistrationManagement
-
-    Group.belongsTo(Topic, {
-      as: 'topic'
+  sequelize
+    .authenticate()
+    .then(() => {
+      console.log('Connection has been established successfully.')
     })
-    Group.belongsTo(Configuration, {
-      as: 'configuration'
-    })
-    Group.belongsToMany(User, {
-      through: 'group_students',
-      as: 'students'
-    })
-    User.belongsToMany(Group, {
-      through: 'group_students',
-      as: 'groups'
-    })
-    Group.belongsTo(User, {
-      as: 'instructor',
-      foreignKey: 'instructorId'
+    .catch((err) => {
+      console.error('Unable to connect to the database:', err)
+      process.exit(1)
     })
 
-    db.Configuration.associate(db)
-    db.Registration.associate(db)
+  const UserModel = require('./user')
+  const GroupModel = require('./group')
+  const TopicModel = require('./topic')
+  const TopicDateModel = require('./topic_date')
+  const RegistrationModel = require('./registration')
+  const ConfigurationModel = require('./configuration')
+  const RegistrationQuestionSetModel = require('./registration_question_set')
+  const ReviewQuestionSetModel = require('./review_question_set')
+  //const Review = require('./review')
+  //const Review_answer = require('./review_answer')
+  const RegistrationManagementModel = require('./registration_management')
 
-    db.sequelize = sequelize
-    db.Sequelize = Sequelize
-    sequelize.sync()
-  }, 9000)
+  const User = UserModel(sequelize, Sequelize)
+  const Group = GroupModel(sequelize, Sequelize)
+  const Topic = TopicModel(sequelize, Sequelize)
+  const TopicDate = TopicDateModel(sequelize, Sequelize)
+  const Registration = RegistrationModel(sequelize, Sequelize)
+  const Configuration = ConfigurationModel(sequelize, Sequelize)
+  const RegistrationQuestionSet = RegistrationQuestionSetModel(
+    sequelize,
+    Sequelize
+  )
+  const ReviewQuestionSet = ReviewQuestionSetModel(sequelize, Sequelize)
+  const RegistrationManagement = RegistrationManagementModel(
+    sequelize,
+    Sequelize
+  )
+
+  db.User = User
+  db.Group = Group
+  db.Topic = Topic
+  db.TopicDate = TopicDate
+  db.Registration = Registration
+  db.Configuration = Configuration
+  db.RegistrationQuestionSet = RegistrationQuestionSet
+  db.ReviewQuestionSet = ReviewQuestionSet
+  db.RegistrationManagement = RegistrationManagement
+
+  Group.belongsTo(Topic, {
+    as: 'topic'
+  })
+  Group.belongsTo(Configuration, {
+    as: 'configuration'
+  })
+  Group.belongsToMany(User, {
+    through: 'group_students',
+    as: 'students'
+  })
+  User.belongsToMany(Group, {
+    through: 'group_students',
+    as: 'groups'
+  })
+  Group.belongsTo(User, {
+    as: 'instructor',
+    foreignKey: 'instructorId'
+  })
+
+  db.Configuration.associate(db)
+  db.Registration.associate(db)
+
+  db.sequelize = sequelize
+  db.Sequelize = Sequelize
+  sequelize.sync()
 }
 
 module.exports = db


### PR DESCRIPTION
Sequelize was previously waiting for 9 seconds before connecting to the
database. This was "because it would crash if the db is not up". Crashing is,
however, desired behavior for us, as docker-compose will keep restarting the
backend until db is ready.

If connection fails, backend exits with code 1.